### PR TITLE
ROS 2 Gazebo対応

### DIFF
--- a/sciurus17_description/robot_description_loader.py
+++ b/sciurus17_description/robot_description_loader.py
@@ -13,9 +13,11 @@ class RobotDescriptionLoader():
             get_package_share_directory('sciurus17_description'),
             'urdf',
             'sciurus17.urdf.xacro')
+        self.use_gazebo = 'false'
 
     def load(self):
         return Command([
                 'xacro ',
-                self.robot_description_path
+                self.robot_description_path,
+                ' use_gazebo:=', self.use_gazebo
                 ])

--- a/test/test_robot_description_loader.py
+++ b/test/test_robot_description_loader.py
@@ -25,3 +25,10 @@ def test_change_description_path():
     with pytest.raises(Exception) as e:
         exec_load(rdl)
     assert e.value
+
+
+def test_use_gazebo():
+    # use_gazeboが変更され、xacroにgazeboタグがセットされることを期待
+    rdl = RobotDescriptionLoader()
+    rdl.use_gazebo = 'true'
+    assert '<gazebo' in exec_load(rdl)

--- a/urdf/sciurus17.urdf.xacro
+++ b/urdf/sciurus17.urdf.xacro
@@ -1,16 +1,26 @@
 <?xml version="1.0"?>
 
-<robot name="sciurus17" xmlns:xacro="http://ros.org/wiki/xacro" >
+<robot
+    name="sciurus17"
+    xmlns:xacro="http://ros.org/wiki/xacro"
+    xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+    xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+    xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface">
+
   <xacro:include filename="$(find sciurus17_description)/urdf/sciurus17_body.xacro"/>
   <xacro:include filename="$(find sciurus17_description)/urdf/sciurus17_head.xacro"/>
   <xacro:include filename="$(find sciurus17_description)/urdf/sciurus17_right_arm.xacro"/>
   <xacro:include filename="$(find sciurus17_description)/urdf/sciurus17_right_hand.xacro"/>
   <xacro:include filename="$(find sciurus17_description)/urdf/sciurus17_left_arm.xacro"/>
   <xacro:include filename="$(find sciurus17_description)/urdf/sciurus17_left_hand.xacro"/>
+  <xacro:include filename="$(find sciurus17_description)/urdf/sciurus17_gazebo.xacro"/>
+
+  <xacro:arg name="use_gazebo" default="false" />
 
   <material name="white">
     <color rgba="0.9 0.9 0.9 1.0"/>
   </material>
+
   <material name="red">
     <color rgba="0.8984375 0.0 0.0703125 1"/>
   </material>
@@ -129,55 +139,6 @@
   <xacro:property name="COLOR_LINK_HAND" value="red"/>
   <xacro:property name="COLOR_LINK_CAMERA" value="white"/>
 
-  <xacro:arg name="use_gazebo_simulation" default="false" />
-  <xacro:arg name="load_trans1" default="false" />
-  <xacro:arg name="load_trans2" default="false" />
-  <xacro:arg name="load_trans3" default="false" />
-
-  <xacro:arg name="use_effort_right_arm" default="false" />
-  <xacro:property name="right_arm_interface" value="position"/>
-  <xacro:if value="$(arg use_effort_right_arm)">
-    <xacro:property name="right_arm_interface" value="effort"/>
-  </xacro:if>
-
-  <xacro:arg name="use_effort_left_wrist" default="false" />
-  <xacro:property name="left_wrist_interface" value="position"/>
-  <xacro:if value="$(arg use_effort_left_wrist)">
-    <xacro:property name="left_wrist_interface" value="effort"/>
-  </xacro:if>
-
-  <xacro:if value="$(arg use_gazebo_simulation)">
-    <xacro:include filename="$(find sciurus17_description)/urdf/sciurus17_gazebo.xacro"/>
-
-    <xacro:if value="$(arg load_trans1)">
-      <xacro:default_transmission joint_name="r_arm_joint1" interface="${right_arm_interface}"/>
-      <xacro:default_transmission joint_name="r_arm_joint2" interface="${right_arm_interface}"/>
-      <xacro:default_transmission joint_name="r_arm_joint3" interface="${right_arm_interface}"/>
-      <xacro:default_transmission joint_name="r_arm_joint4" interface="${right_arm_interface}"/>
-      <xacro:default_transmission joint_name="r_arm_joint5" interface="${right_arm_interface}"/>
-      <xacro:default_transmission joint_name="r_arm_joint6" interface="${right_arm_interface}"/>
-      <xacro:default_transmission joint_name="r_arm_joint7" interface="${right_arm_interface}"/>
-      <xacro:default_transmission joint_name="r_hand_joint"/>
-    </xacro:if>
-
-    <xacro:if value="$(arg load_trans2)">
-      <xacro:default_transmission joint_name="l_arm_joint1"/>
-      <xacro:default_transmission joint_name="l_arm_joint2"/>
-      <xacro:default_transmission joint_name="l_arm_joint3"/>
-      <xacro:default_transmission joint_name="l_arm_joint4"/>
-      <xacro:default_transmission joint_name="l_arm_joint5"/>
-      <xacro:default_transmission joint_name="l_arm_joint6"/>
-      <xacro:default_transmission joint_name="l_arm_joint7" interface="${left_wrist_interface}"/>
-      <xacro:default_transmission joint_name="l_hand_joint"/>
-    </xacro:if>
-
-    <xacro:if value="$(arg load_trans3)">
-      <xacro:default_transmission joint_name="waist_yaw_joint"/>
-      <xacro:default_transmission joint_name="neck_yaw_joint"/>
-      <xacro:default_transmission joint_name="neck_pitch_joint"/>
-    </xacro:if>
-  </xacro:if>
-
   <!-- Used for fixing robot 'base_link'  to Gazebo 'world' -->
   <link name="world"/>
 
@@ -198,4 +159,7 @@
 
   <xacro:sciurus17_left_hand/>
 
+  <xacro:if value="$(arg use_gazebo)">
+    <xacro:gazebo_robot_settings/>
+  </xacro:if>
 </robot>

--- a/urdf/sciurus17_body.xacro
+++ b/urdf/sciurus17_body.xacro
@@ -79,16 +79,6 @@
       </collision>
     </link>
 
-    <gazebo reference="${NAME_LINK_BASE}">
-      <material>Gazebo/White</material>
-    </gazebo>
-    <gazebo reference="${NAME_LINK_BODY}">
-      <material>Gazebo/White</material>
-    </gazebo>
-    <gazebo reference="${NAME_LINK_CHEST_CAMERA}">
-      <material>Gazebo/Black</material>
-    </gazebo>
-
   </xacro:macro>
 
 </robot>

--- a/urdf/sciurus17_gazebo.xacro
+++ b/urdf/sciurus17_gazebo.xacro
@@ -2,168 +2,138 @@
 
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:macro name="default_transmission" 
-    params="joint_name interface:=position">
-
-    <transmission name="${joint_name}_trans">
-      <provideFeedback>true</provideFeedback>
-      <implicitSpringDamper>0</implicitSpringDamper>
-      <motorTorqueConstant>0.418</motorTorqueConstant>
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${joint_name}">
-        <xacro:if value="${interface == 'position'}">
-          <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
-        </xacro:if>
-        <xacro:if value="${interface == 'velocity'}">
-          <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
-        </xacro:if>
-        <xacro:if value="${interface == 'effort'}">
-          <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
-        </xacro:if>
-      </joint>
-      <actuator name="{joint_name}_motor">
-        <xacro:if value="${interface == 'position'}">
-          <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
-        </xacro:if>
-        <xacro:if value="${interface == 'velocity'}">
-          <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
-        </xacro:if>
-        <xacro:if value="${interface == 'effort'}">
-          <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
-        </xacro:if>
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
+  <xacro:macro name="material_gazebo_black">
+    <visual>
+      <material>
+        <ambient>0.2 0.2 0.2 1</ambient>
+        <diffuse>0.0 0.0 0.0 1</diffuse>
+      </material>
+    </visual>
   </xacro:macro>
 
-  <gazebo reference="body_link">
-    <sensor name='camera1' type='camera'>
-      <update_rate>30</update_rate>
-      <camera name='head'>
-        <horizontal_fov>1.39626</horizontal_fov>
-        <image>
-          <width>1280</width>
-          <height>800</height>
-          <format>R8G8B8</format>
-        </image>
-        <clip>
-          <near>0.02</near>
-          <far>300</far>
-        </clip>
-        <noise>
-          <type>gaussian</type>
-          <mean>0</mean>
-          <stddev>0.007</stddev>
-        </noise>
-      </camera>
-      <plugin name='camera_controller' filename='libgazebo_ros_camera.so'>
-        <alwaysOn>true</alwaysOn>
-        <updateRate>0.0</updateRate>
-        <cameraName>sciurus17/chest_camera_node</cameraName>
-        <imageTopicName>image</imageTopicName>
-        <cameraInfoTopicName>camera_info</cameraInfoTopicName>
-        <frameName>chest_camera_link</frameName>
-        <hackBaseline>0.07</hackBaseline>
-        <distortionK1>0.0</distortionK1>
-        <distortionK2>0.0</distortionK2>
-        <distortionK3>0.0</distortionK3>
-        <distortionT1>0.0</distortionT1>
-        <distortionT2>0.0</distortionT2>
-      </plugin>
-      <pose frame=''>0.114576 0 0.217659 0 0.5236 0</pose>
-    </sensor>
-  </gazebo>
+  <xacro:macro name="material_gazebo_white">
+    <visual>
+      <material>
+        <ambient>0.95 0.95 0.95 1</ambient>
+        <diffuse>0.95 0.95 0.95 1</diffuse>
+      </material>
+    </visual>
+  </xacro:macro>
 
-  <gazebo reference="neck_pitch_link">
-    <sensor name='openni_camera_camera' type='depth'>
-      <always_on>1</always_on>
-      <visualize>1</visualize>
-      <camera name='__default__'>
-        <horizontal_fov>1.047</horizontal_fov>
-        <image>
-          <width>640</width>
-          <height>480</height>
-          <format>B8G8R8</format>
-        </image>
-        <depth_camera>
-          <output>depths</output>
-        </depth_camera>
-        <clip>
-          <near>0.1</near>
-          <far>100</far>
-        </clip>
-      </camera>
-      <plugin name='camera_controller' filename='libgazebo_ros_openni_kinect.so'>
-        <robotNamespace>sciurus17</robotNamespace>
-        <alwaysOn>true</alwaysOn>
-        <updateRate>10.0</updateRate>
-        <cameraName>camera</cameraName>
-        <frameName>/camera_color_optical_frame</frameName>
-        <imageTopicName>color/image_raw</imageTopicName>
-        <depthImageTopicName>depth/image_raw</depthImageTopicName>
-        <pointCloudTopicName>depth_registered/points</pointCloudTopicName>
-        <cameraInfoTopicName>color/camera_info</cameraInfoTopicName>
-        <depthImageCameraInfoTopicName>depth/camera_info</depthImageCameraInfoTopicName>
-        <pointCloudCutoff>0.4</pointCloudCutoff>
-        <hackBaseline>0.07</hackBaseline>
-        <distortionK1>0.0</distortionK1>
-        <distortionK2>0.0</distortionK2>
-        <distortionK3>0.0</distortionK3>
-        <distortionT1>0.0</distortionT1>
-        <distortionT2>0.0</distortionT2>
-        <CxPrime>0.0</CxPrime>
-        <Cx>0.0</Cx>
-        <Cy>0.0</Cy>
-        <focalLength>0.0</focalLength>
-      </plugin>
-      <pose frame=''>0.081785 0.03522 0.091 0 -0 0</pose>
-    </sensor>
-  </gazebo>
+  <xacro:macro name="material_gazebo_red">
+    <visual>
+      <material>
+        <ambient>1.0 0.3 0.3 1</ambient>
+        <diffuse>1.0 0.0 0.0 1</diffuse>
+      </material>
+    </visual>
+  </xacro:macro>
 
-  <joint name="camera_color_optical_joint" type="fixed">
-    <origin xyz="0 0.015 0" rpy="-1.5708 0 -1.5708"/>
-    <parent link="camera_link"/>
-    <child link="camera_color_optical_frame"/>
-  </joint>
-  <link name="camera_color_optical_frame"/>
+  <xacro:macro name="gazebo_robot_settings">
 
-  <joint name="camera_depth_optical_joint" type="fixed">
-    <origin xyz="0 0.015 0" rpy="-1.5708 0 -1.5708"/>
-    <parent link="camera_link"/>
-    <child link="camera_depth_optical_frame"/>
-  </joint>
-  <link name="camera_depth_optical_frame"/>
+    <gazebo reference="${NAME_LINK_BASE}">
+      <xacro:material_gazebo_white/>
+    </gazebo>
 
-  <gazebo>
-    <plugin name='gazebo_ros_control1' filename='libgazebo_ros_control.so'>
-      <robotNamespace>/sciurus17/controller1</robotNamespace>
-      <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
-      <legacyModeNS>false</legacyModeNS>
-    </plugin>
+    <gazebo reference="${NAME_LINK_BODY}">
+      <xacro:material_gazebo_white/>
+    </gazebo>
 
-    <plugin name='gazebo_ros_control2' filename='libgazebo_ros_control.so'>
-      <robotNamespace>/sciurus17/controller2</robotNamespace>
-      <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
-      <legacyModeNS>false</legacyModeNS>
-    </plugin>
+    <gazebo reference="${NAME_LINK_CHEST_CAMERA}">
+      <xacro:material_gazebo_black/>
+    </gazebo>
 
-    <plugin name='gazebo_ros_control3' filename='libgazebo_ros_control.so'>
-      <robotNamespace>/sciurus17/controller3</robotNamespace>
-      <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
-      <legacyModeNS>false</legacyModeNS>
-    </plugin>
+    <gazebo reference="${NAME_LINK_NECK_1}">
+      <xacro:material_gazebo_white/>
+    </gazebo>
 
-    <plugin name="r_hand_mimic_joint_plugin" filename="libroboticsgroup_upatras_gazebo_mimic_joint_plugin.so">
-      <joint>r_hand_joint</joint>
-      <mimicJoint>r_hand_mimic_joint</mimicJoint>
-      <multiplier>1.0</multiplier>
-    </plugin>
+    <gazebo reference="${NAME_LINK_NECK_2}">
+      <xacro:material_gazebo_white/>
+    </gazebo>
 
-    <plugin name="l_hand_mimic_joint_plugin" filename="libroboticsgroup_upatras_gazebo_mimic_joint_plugin.so">
-      <joint>l_hand_joint</joint>
-      <mimicJoint>l_hand_mimic_joint</mimicJoint>
-      <multiplier>1.0</multiplier>
-    </plugin>
-  </gazebo>
+    <gazebo reference="${NAME_LINK_HEAD_CAMERA}">
+      <xacro:material_gazebo_black/>
+    </gazebo>
 
+    <gazebo reference="${NAME_LINK_ARM_R_1}">
+      <xacro:material_gazebo_white/>
+    </gazebo>
+
+    <gazebo reference="${NAME_LINK_ARM_R_2}">
+      <xacro:material_gazebo_white/>
+    </gazebo>
+
+    <gazebo reference="${NAME_LINK_ARM_R_3}">
+      <xacro:material_gazebo_white/>
+    </gazebo>
+
+    <gazebo reference="${NAME_LINK_ARM_R_4}">
+      <xacro:material_gazebo_white/>
+    </gazebo>
+
+    <gazebo reference="${NAME_LINK_ARM_R_5}">
+      <xacro:material_gazebo_white/>
+    </gazebo>
+
+    <gazebo reference="${NAME_LINK_ARM_R_6}">
+      <xacro:material_gazebo_white/>
+    </gazebo>
+
+    <gazebo reference="${NAME_LINK_ARM_R_7}">
+      <xacro:material_gazebo_red/>
+    </gazebo>
+
+    <gazebo reference="${NAME_LINK_HAND_R_A}">
+      <mu1>0.8</mu1>
+      <mu2>0.8</mu2>
+      <xacro:material_gazebo_red/>
+    </gazebo>
+
+    <gazebo reference="${NAME_LINK_HAND_R_B}">
+      <mu1>0.8</mu1>
+      <mu2>0.8</mu2>
+      <xacro:material_gazebo_red/>
+    </gazebo>
+
+    <gazebo reference="${NAME_LINK_ARM_L_1}">
+      <xacro:material_gazebo_white/>
+    </gazebo>
+
+    <gazebo reference="${NAME_LINK_ARM_L_2}">
+      <xacro:material_gazebo_white/>
+    </gazebo>
+
+    <gazebo reference="${NAME_LINK_ARM_L_3}">
+      <xacro:material_gazebo_white/>
+    </gazebo>
+
+    <gazebo reference="${NAME_LINK_ARM_L_4}">
+      <xacro:material_gazebo_white/>
+    </gazebo>
+
+    <gazebo reference="${NAME_LINK_ARM_L_5}">
+      <xacro:material_gazebo_white/>
+    </gazebo>
+
+    <gazebo reference="${NAME_LINK_ARM_L_6}">
+      <xacro:material_gazebo_white/>
+    </gazebo>
+
+    <gazebo reference="${NAME_LINK_ARM_L_7}">
+      <xacro:material_gazebo_red/>
+    </gazebo>
+
+    <gazebo reference="${NAME_LINK_HAND_L_A}">
+      <mu1>0.8</mu1>
+      <mu2>0.8</mu2>
+      <xacro:material_gazebo_red/>
+    </gazebo>
+
+    <gazebo reference="${NAME_LINK_HAND_L_B}">
+      <mu1>0.8</mu1>
+      <mu2>0.8</mu2>
+      <xacro:material_gazebo_red/>
+    </gazebo>
+
+  </xacro:macro>
 </robot>

--- a/urdf/sciurus17_head.xacro
+++ b/urdf/sciurus17_head.xacro
@@ -92,16 +92,6 @@
       </collision>
     </link>
 
-    <gazebo reference="${NAME_LINK_NECK_1}">
-      <material>Gazebo/White</material>
-    </gazebo>
-    <gazebo reference="${NAME_LINK_NECK_2}">
-      <material>Gazebo/White</material>
-    </gazebo>
-    <gazebo reference="${NAME_LINK_HEAD_CAMERA}">
-      <material>Gazebo/Black</material>
-    </gazebo>
-
   </xacro:macro>
 
 </robot>

--- a/urdf/sciurus17_left_arm.xacro
+++ b/urdf/sciurus17_left_arm.xacro
@@ -55,14 +55,14 @@
       <visual>
         <origin rpy="0 -1.5708 0" xyz="0.0 0.0 0.0"/>
         <geometry>
-          <mesh filename="package://sciurus17_description/meshes/visual/L_Link2.stl" scale="-1.0 1.0 -1.0"/>
+          <mesh filename="package://sciurus17_description/meshes/visual/L_Link2.stl" scale="1.0 1.0 1.0"/>
         </geometry>
         <material name="${COLOR_LINK_ARM}"/>
       </visual>
       <collision>
         <origin rpy="0 -1.5708 0" xyz="0.0 0.0 0.0"/>
         <geometry>
-          <mesh filename="package://sciurus17_description/meshes/collision/L_Link2.stl" scale="-1.0 1.0 -1.0"/>
+          <mesh filename="package://sciurus17_description/meshes/collision/L_Link2.stl" scale="1.0 1.0 1.0"/>
         </geometry>
       </collision>
       <inertial>
@@ -260,25 +260,6 @@
       <axis xyz="0 1 0"/>
       <dynamics damping="1.0e-6" friction="0.8"/>
     </joint>
-
-    <gazebo reference="${NAME_LINK_ARM_L_1}">
-      <material>Gazebo/White</material>
-    </gazebo>
-    <gazebo reference="${NAME_LINK_ARM_L_2}">
-      <material>Gazebo/White</material>
-    </gazebo>
-    <gazebo reference="${NAME_LINK_ARM_L_3}">
-      <material>Gazebo/White</material>
-    </gazebo>
-    <gazebo reference="${NAME_LINK_ARM_L_4}">
-      <material>Gazebo/White</material>
-    </gazebo>
-    <gazebo reference="${NAME_LINK_ARM_L_5}">
-      <material>Gazebo/White</material>
-    </gazebo>
-    <gazebo reference="${NAME_LINK_ARM_L_6}">
-      <material>Gazebo/White</material>
-    </gazebo>
 
   </xacro:macro>
 

--- a/urdf/sciurus17_left_hand.xacro
+++ b/urdf/sciurus17_left_hand.xacro
@@ -94,16 +94,6 @@
       </inertial>
     </link>
 
-    <gazebo reference="${NAME_LINK_ARM_L_7}">
-      <material>Gazebo/Red</material>
-    </gazebo>
-    <gazebo reference="${NAME_LINK_HAND_L_A}">
-      <material>Gazebo/Red</material>
-    </gazebo>
-    <gazebo reference="${NAME_LINK_HAND_L_B}">
-      <material>Gazebo/Red</material>
-    </gazebo>
-
   </xacro:macro>
 
 </robot>

--- a/urdf/sciurus17_right_arm.xacro
+++ b/urdf/sciurus17_right_arm.xacro
@@ -89,14 +89,14 @@
       <visual>
         <origin rpy="1.5708 0 0" xyz="0.0 0.0 0.0"/>
         <geometry>
-          <mesh filename="package://sciurus17_description/meshes/visual/L_Link3.stl" scale="1.0 -1.0 1.0"/>
+          <mesh filename="package://sciurus17_description/meshes/visual/L_Link3.stl" scale="1.0 1.0 1.0"/>
         </geometry>
         <material name="${COLOR_LINK_ARM}"/>
       </visual>
       <collision>
         <origin rpy="1.5708 0 0" xyz="0.0 0.0 0.0"/>
         <geometry>
-          <mesh filename="package://sciurus17_description/meshes/collision/L_Link3.stl" scale="1.0 -1.0 1.0"/>
+          <mesh filename="package://sciurus17_description/meshes/collision/L_Link3.stl" scale="1.0 1.0 1.0"/>
         </geometry>
       </collision>
       <inertial>
@@ -260,25 +260,6 @@
       <axis xyz="0 -1 0"/>
       <dynamics damping="1.0e-6" friction="0.8"/>
     </joint>
-
-    <gazebo reference="${NAME_LINK_ARM_R_1}">
-      <material>Gazebo/White</material>
-    </gazebo>
-    <gazebo reference="${NAME_LINK_ARM_R_2}">
-      <material>Gazebo/White</material>
-    </gazebo>
-    <gazebo reference="${NAME_LINK_ARM_R_3}">
-      <material>Gazebo/White</material>
-    </gazebo>
-    <gazebo reference="${NAME_LINK_ARM_R_4}">
-      <material>Gazebo/White</material>
-    </gazebo>
-    <gazebo reference="${NAME_LINK_ARM_R_5}">
-      <material>Gazebo/White</material>
-    </gazebo>
-    <gazebo reference="${NAME_LINK_ARM_R_6}">
-      <material>Gazebo/White</material>
-    </gazebo>
 
   </xacro:macro>
 

--- a/urdf/sciurus17_right_hand.xacro
+++ b/urdf/sciurus17_right_hand.xacro
@@ -96,16 +96,6 @@
       </inertial>
     </link>
 
-    <gazebo reference="${NAME_LINK_ARM_R_7}">
-      <material>Gazebo/Red</material>
-    </gazebo>
-    <gazebo reference="${NAME_LINK_HAND_R_A}">
-      <material>Gazebo/Red</material>
-    </gazebo>
-    <gazebo reference="${NAME_LINK_HAND_R_B}">
-      <material>Gazebo/Red</material>
-    </gazebo>
-
   </xacro:macro>
 
 </robot>


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
ROS 2のGazebo上でモデルが表示されるためにTransmission等古い記述を削除しました。
マテリアルの設定を[CRANE-X7](https://github.com/rt-net/crane_x7_description/tree/ros2)と同じ表記に統一しました。
controllerは未対応のためアクチュエータは動作しません。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
Gazeboを起動するlaunchファイルは下記PRを参照してください。
https://github.com/rt-net/sciurus17_ros/pull/140

下記コマンドでGazeboを起動し、モデルが表示されることを確認しました。
```
ros2 launch sciurus17_gazebo sciurus17_with_table.launch.py
```

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
