### PR TITLE
use_gazeboがtrueの時だけworldリンクを定義する

### DIFF
--- a/launch/display.rviz
+++ b/launch/display.rviz
@@ -3,11 +3,9 @@ Panels:
     Help Height: 78
     Name: Displays
     Property Tree Widget:
-      Expanded:
-        - /Global Options1
-        - /Status1
+      Expanded: ~
       Splitter Ratio: 0.5
-    Tree Height: 542
+    Tree Height: 707
   - Class: rviz_common/Selection
     Name: Selection
   - Class: rviz_common/Tool Properties
@@ -194,10 +192,6 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        world:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
       Mass Properties:
         Inertia: false
         Mass: false
@@ -265,49 +259,46 @@ Visualization Manager:
           Value: true
         r_link7:
           Value: true
-        world:
-          Value: true
       Marker Scale: 0.5
       Name: TF
       Show Arrows: true
       Show Axes: true
       Show Names: true
       Tree:
-        world:
-          base_link:
-            body_link:
-              chest_camera_link:
-                {}
-              l_link1:
-                l_link2:
-                  l_link3:
-                    l_link4:
-                      l_link5:
-                        l_link5_armarker:
-                          {}
-                        l_link6:
-                          l_link7:
-                            l_gripperA_link:
-                              {}
-                            l_gripperB_link:
-                              {}
-              neck_yaw_link:
-                neck_pitch_link:
-                  head_camera_link:
-                    {}
-              r_link1:
-                r_link2:
-                  r_link3:
-                    r_link4:
-                      r_link5:
-                        r_link5_armarker:
-                          {}
-                        r_link6:
-                          r_link7:
-                            r_gripperA_link:
-                              {}
-                            r_gripperB_link:
-                              {}
+        base_link:
+          body_link:
+            chest_camera_link:
+              {}
+            l_link1:
+              l_link2:
+                l_link3:
+                  l_link4:
+                    l_link5:
+                      l_link5_armarker:
+                        {}
+                      l_link6:
+                        l_link7:
+                          l_gripperA_link:
+                            {}
+                          l_gripperB_link:
+                            {}
+            neck_yaw_link:
+              neck_pitch_link:
+                head_camera_link:
+                  {}
+            r_link1:
+              r_link2:
+                r_link3:
+                  r_link4:
+                    r_link5:
+                      r_link5_armarker:
+                        {}
+                      r_link6:
+                        r_link7:
+                          r_gripperA_link:
+                            {}
+                          r_gripperB_link:
+                            {}
       Update Interval: 0
       Value: true
   Enabled: true
@@ -379,10 +370,10 @@ Visualization Manager:
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 846
+  Height: 1011
   Hide Left Dock: false
   Hide Right Dock: false
-  QMainWindow State: 000000ff00000000fd000000040000000000000156000002acfc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005d00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003f000002ac000000cc00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002acfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003f000002ac000000a900fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004b00000003efc0100000002fb0000000800540069006d00650100000000000004b00000026f00fffffffb0000000800540069006d006501000000000000045000000000000000000000023f000002ac00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd00000004000000000000015600000351fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005d00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003f00000351000000cc00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f00000351fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003f00000351000000a900fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073e0000003efc0100000002fb0000000800540069006d006501000000000000073e0000026f00fffffffb0000000800540069006d00650100000000000004500000000000000000000004cd0000035100000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -391,6 +382,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: false
-  Width: 1200
-  X: 237
-  Y: 81
+  Width: 1854
+  X: 66
+  Y: 32

--- a/test/test_robot_description_loader.py
+++ b/test/test_robot_description_loader.py
@@ -52,13 +52,31 @@ def test_manipulator_config_file_path():
     assert '"manipulator_config_file_path">test/config/file/path' in exec_load(rdl)
 
 
-def test_use_gazebo():
+def test_use_gazebo_ros2_control():
     # use_gazeboが変更され、xacroにgz_ros2_controlがセットされることを期待
     rdl = RobotDescriptionLoader()
     rdl.use_gazebo = 'true'
     rdl.gz_control_config_package = 'sciurus17_description'
     rdl.gz_control_config_file_path = 'config/dummy_controllers.yaml'
     assert 'gz_ros2_control/GazeboSimSystem' in exec_load(rdl)
+
+
+def test_use_gazebo_true_world_link():
+    # use_gazeboが変更され、xacroにworldリンクがセットされることを期待
+    rdl = RobotDescriptionLoader()
+    rdl.use_gazebo = 'true'
+    rdl.gz_control_config_package = 'sciurus17_description'
+    rdl.gz_control_config_file_path = 'config/dummy_controllers.yaml'
+    assert 'gz_ros2_control/GazeboSimSystem' in exec_load(rdl)
+    assert 'link name="world"' in exec_load(rdl)
+
+
+def test_use_gazebo_false_world_link():
+    # use_gazebo=falseではworldリンクがセットされないことを期待
+    rdl = RobotDescriptionLoader()
+    rdl.use_gazebo = 'false'
+    xml = exec_load(rdl)
+    assert 'link name="world"' not in xml
 
 
 def test_use_gazebo_head_camera():

--- a/urdf/sciurus17.urdf.xacro
+++ b/urdf/sciurus17.urdf.xacro
@@ -173,13 +173,15 @@
   <xacro:property name="COLOR_LINK_ARM" value="white"/>
   <xacro:property name="COLOR_LINK_GRIPPER" value="red"/>
 
-  <!-- Used for fixing robot 'base_link'  to Gazebo 'world' -->
-  <link name="world"/>
+  <xacro:if value="$(arg use_gazebo)">
+    <!-- Used for fixing robot 'base_link'  to Gazebo 'world' -->
+    <link name="world"/>
 
-  <joint name="${NAME_JOINT_BASE}" type="fixed">
-    <parent link="world"/>
-    <child link="${NAME_LINK_BASE}"/>
-  </joint>
+    <joint name="${NAME_JOINT_BASE}" type="fixed">
+      <parent link="world"/>
+      <child link="${NAME_LINK_BASE}"/>
+    </joint>
+  </xacro:if>
 
   <xacro:sciurus17_body/>
 


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
worldリンクはGazebo以外では不要なため、use_gazeboがtrueの時だけ定義するように修正します。
worldリンクが定義されているかどうかのテストも追加します。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
display.launch.py実行時にworldリンクが定義されていないことを確認しました。
sciurus17_rosでMockComponentとGazeboでそれぞれ動作確認しました。

# Any other comments?
<!-- その他コメントはありますか？ -->
sciurus17_rosのRVizの設定ファイルではfixed frameがworldに設定されているためbase_linkに変更する必要があります。
また、sciurus17.srdfのbase_link_to_world_jointが不要になるため削除したほうがよさそうです。
https://github.com/rt-net/sciurus17_ros/blob/ros2/sciurus17_moveit_config/config/sciurus17.srdf#L151

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
